### PR TITLE
#115: Adding default stack for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,5 @@ coverage.info
 coverage.json
 TestCoverage.info
 .idea
+stack/terraform/.terraform/**/*
+stack/terraform/.terraform.lock.hcl

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -1,0 +1,27 @@
+# Stack of terraform and localstack
+services:
+  localstack:
+    container_name: "localstack-main"
+    image: localstack/localstack
+    ports:
+      - "4566:4566" # LocalStack Gateway
+      #- "127.0.0.1:4510-4559:4510-4559"  # external services port range
+    environment:
+      # LocalStack configuration: https://docs.localstack.cloud/references/configuration/
+      #- DEBUG=${DEBUG:-0}
+      - SERVICES=s3, sqs, sts
+      - DEFAULT_REGION=eu-west-2
+      - DEBUG=0
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+      - "./localstack-init.sh:/etc/localstack/init/ready.d/init-aws.sh" # ready hook
+
+  terraform:
+    container_name: "terraform"
+    build:
+      context: .
+      dockerfile: terraform.Dockerfile
+    depends_on:
+      - localstack
+    volumes:
+      - "./terraform:/terraform"

--- a/stack/localstack-init.sh
+++ b/stack/localstack-init.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+awslocal s3 mb s3://tfstate

--- a/stack/terraform.Dockerfile
+++ b/stack/terraform.Dockerfile
@@ -1,0 +1,8 @@
+FROM hashicorp/terraform:latest
+COPY tf.sh ./
+RUN chmod +x ./tf.sh
+WORKDIR /terraform
+#COPY ./terraform .
+
+
+ENTRYPOINT [ "/tf.sh" ]

--- a/stack/terraform/components/s3/main.tf
+++ b/stack/terraform/components/s3/main.tf
@@ -1,0 +1,7 @@
+resource "aws_s3_bucket" "component_to_s3" {
+    bucket = "kyameru-component-s3"
+    tags = {
+        Name = "Kyameru component S3 to bucket"
+        Environment = "local"
+    }
+}

--- a/stack/terraform/main.tf
+++ b/stack/terraform/main.tf
@@ -1,0 +1,40 @@
+# Main tf entry
+
+terraform {
+    backend "s3" {
+    bucket = "tfstate"
+    key    = "local.tfstate"
+    region = "eu-west-2"
+    endpoint                    = "http://localstack-main:4566"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    force_path_style            = true
+    #dynamodb_table              = "terraform_state"
+    #dynamodb_endpoint           = "http://localhost:4566"
+    #encrypt                     = true
+    access_key                  = "mock_access_key"
+    secret_key                  = "mock_secret_key"
+    skip_requesting_account_id = true
+  }
+}
+
+provider "aws" {
+
+  access_key = "test"
+  secret_key = "test"
+  region     = "eu-west-2"
+
+  s3_use_path_style           = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    s3             = "http://localstack-main:4566"
+  }
+}
+
+# Components
+module "component_to" {
+    source = "./components/s3"
+}

--- a/stack/tf.sh
+++ b/stack/tf.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+terraform init
+terraform plan
+terraform apply -auto-approve


### PR DESCRIPTION
Added a default stack with a single "component" of S3 (ready for the first AWS component).
Stack pulls latest and builds a terraform stack to run.

Terraform runs in a separate container so that it is isolated away from any local machine config or AWS accounts.

Probably can remove the plan stage later, just get it working for now. No release needed, this is just for local testing